### PR TITLE
Redirect to landing URL after login

### DIFF
--- a/src/app/components/newuser/newuser.component.ts
+++ b/src/app/components/newuser/newuser.component.ts
@@ -24,7 +24,7 @@ export class NewuserComponent implements OnInit {
     this.userService.create(this.name).pipe(take(1)).subscribe(
       (user: any) => {
         this.userService.saveUserId(user.id);
-        this.router.navigate(['/myvotes']);
+        this.router.navigate([this.userService.savedUrl || '/myvotes']);
       },
       (error: any) => this.error = true 
     );

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,12 +1,15 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { NavigationCancel, NavigationEnd, Router } from '@angular/router';
 import { environment } from '../../environments/environment';
 
 @Injectable({
   providedIn: 'root'
 })
 export class UserService {
-  
+
+  savedUrl: string;
+
   getUserId() {
     return localStorage.getItem('green-room-user-id');
   }
@@ -15,7 +18,19 @@ export class UserService {
     return localStorage.setItem('green-room-user-id', id);
   }
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private router: Router) {
+    router.events.subscribe((event) => {
+      if (event instanceof NavigationCancel) {
+        // Saving URL from canceled route.
+        this.savedUrl = event.url;
+      } else if (event instanceof NavigationEnd) {
+        // If user navigates away from sign-in page, clearing saved URL.
+        if (!event.url.match(/^\/newuser/)) {
+          this.savedUrl = null;
+        }
+      }
+    });
+  }
 
   isLoggedIn() {
     return localStorage.getItem('green-room-user-id') !== null;


### PR DESCRIPTION
Currently, if an user discovers the app by a room invitation, once the user has logged in they should click the room invitation again.

We can make it so they don't need to do that